### PR TITLE
Treat softbreak as a space

### DIFF
--- a/lib/phlex/markdown.rb
+++ b/lib/phlex/markdown.rb
@@ -25,9 +25,9 @@ module Phlex
 			case node.type
 			in :document
 				visit_children(node)
-      in :softbreak
-        text(" ")
-        visit_children(node)
+			in :softbreak
+				text(" ")
+				visit_children(node)
 			in :text
 				text(node.string_content)
 			in :header

--- a/lib/phlex/markdown.rb
+++ b/lib/phlex/markdown.rb
@@ -26,7 +26,7 @@ module Phlex
 			in :document
 				visit_children(node)
 			in :softbreak
-				text(" ")
+				whitespace
 				visit_children(node)
 			in :text
 				text(node.string_content)

--- a/lib/phlex/markdown.rb
+++ b/lib/phlex/markdown.rb
@@ -23,8 +23,11 @@ module Phlex
 			return if node.nil?
 
 			case node.type
-			in :document | :softbreak
+			in :document
 				visit_children(node)
+      in :softbreak
+        text(" ")
+        visit_children(node)
 			in :text
 				text(node.string_content)
 			in :header

--- a/test/phlex/markdown.rb
+++ b/test/phlex/markdown.rb
@@ -92,6 +92,17 @@ describe Phlex::Markdown do
 		expect(output).to be == %(<p><img src="src" alt="alt" title="title"></p>)
 	end
 
+	it "supports softbreaks in content as spaces" do
+		output = md <<~MD
+			One
+			Two
+
+			Three
+		MD
+
+		expect(output).to be == "<p>One Two</p><p>Three</p>"
+	end
+
 	def md(content)
 		Phlex::Markdown.new(content).call
 	end


### PR DESCRIPTION
In order to wrap long paragraphs of markdown prose, it's reasonable to
wrap content on many lines and represent [softbreak](https://spec.commonmark.org/0.30/#soft-line-breaks)
as a space in the content. Otherwise it may combine text without spaces,
creating a smattering of joinedwords in the output. Yes, joinedwords was
on purpose to illustrate what the problem output looks like without this change.

### Commentary

It would be nice to support configurability, and markly itself has some options that would be nice to expose, but I'm really not sure the direction this gem might take. I debated hoisting this class directly into my project and modify it because of how straightforward it is.